### PR TITLE
Performance tweaks - sync to async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ scratchpad.js
 gittest
 __tests__/tempdir-*
 debug.txt
+*.0x

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ git diff --cached --name-only --diff-filter=ACMRTUXB | xargs git-date-extractor 
 ## Portfolio / Project Page
 https://joshuatz.com/projects/applications/git-date-extractor-npm-package-and-cli-tool/
 
+## Major updates
+Version | Date | Notes
+--- | --- | ---
+2.0.0 | 11/01/2019 | Refactored a bunch of stuff to be async. Main export is now async, which makes it incompatible with the previous version and necessitated a major version bump.
 
 ## Note about accuracy
 For files that have no git history, this tool has limited accuracy when it comes to creation time (birthtime), especially on Linux, with Node < 10.16.0 and/or Kernel <= 4.11 (where statx is not available).

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ Generic usage:
 ```js
 const gitDateExtractor = require('git-date-extractor');
 
-const stamps = gitDateExtractor.getStamps(optionsObject);
+const stamps = await gitDateExtractor.getStamps(optionsObject);
 ```
 
 Sample demo:
 ```js
 // This will store stamps into `stamps` variable, as well as save to file
-const stamps = gitDateExtractor.getStamps({
+const stamps = await gitDateExtractor.getStamps({
 	outputToFile: true,
 	outputFileName: 'timestamps.json',
 	projectRootPath: __dirname
@@ -91,6 +91,8 @@ console.log(stamps);
 
 ```
 
+> If you prefer callback style of async, you can pass a callback function as the second argument to `getStamps`.
+
 ### Via CLI
 ```
 $ npm install --global git-date-extractor
@@ -114,6 +116,7 @@ $ git-dates --help
 		--allowFiles {string[] | string}
 		--gitCommitHook {"post" | "pre" | "none"} [Default: "none"]
 		--projectRootPath {string}
+		--debug {boolean} [Default: false]
 
 	Examples
 		$ git-date-extractor
@@ -143,6 +146,9 @@ blockFiles | blocklist | Block certain files from being tracked | `string[] or s
 allowFiles | whitelist | Exception list of filepaths that will override certain blocks.<br>See advanced examples section. | `string[] or string | NA
 gitCommitHook | git-stage | Use this if you are running this script on a git hook.<br>For example, use `post` and the script will append a new commit with the changed timestamp file. | `"pre"` or `"post"` or `"none"` | `"none"`
 projectRootPath | rootDir | Top level directory containing your files.<br>Script should be able to detect automatically, but can also pass to be safe. | `string` | Auto-detected based on `proccess.cwd()`<br>or `__dirname`
+debug | debug | Might output extra meta info related to the development of this module | `boolean` | `false`
+
+> Warning: The debug option actually slows down the speed of execution a little due to some overhead related to logging
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "git-date-extractor",
-	"version": "1.0.2",
+	"version": "2.0.0",
 	"description": "Easily extract file dates based on git history, and optionally cache in a easy to parse JSON file.",
 	"license": "MIT",
 	"repository": "joshuatz/git-date-extractor",
@@ -66,7 +66,7 @@
 			"arrow-parens": "off",
 			"brace-style": "off"
 		},
-		"ignores" : [
+		"ignores": [
 			"**/*d.ts"
 		]
 	}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,9 @@
 			"complexity": "off",
 			"arrow-parens": "off",
 			"brace-style": "off"
-		}
+		},
+		"ignores" : [
+			"**/*d.ts"
+		]
 	}
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -19,6 +19,7 @@ const cli = meow(`
 	  --allowFiles {string[] | string}
 	  --gitCommitHook {"post" | "pre" | "none"} [Default: "none"]
 	  --projectRootPath {string}
+	  --debug {boolean} [Default: false]
 
 	Examples
 	  $ git-date-extractor
@@ -86,10 +87,13 @@ const regularArgs = cli.input;
 finalizedOptions.files = finalizedOptions.files.concat(regularArgs);
 
 // Call main with options
-const result = gitDateExtractor.getStamps(finalizedOptions);
-if (finalizedOptions.outputToFile === false) {
-	console.log(result);
-} else {
-	const msg = 'timestamps file updated';
-	console.log(msg);
-}
+gitDateExtractor.getStamps(finalizedOptions).then(result => {
+	if (finalizedOptions.outputToFile === false) {
+		console.log(result);
+	} else {
+		const msg = 'timestamps file updated';
+		console.log(msg);
+	}
+}).catch(error => {
+	console.error(error);
+});

--- a/src/filelist-handler.js
+++ b/src/filelist-handler.js
@@ -102,10 +102,6 @@ const FilelistHandler = (function() {
 				}
 			}
 		}
-		/* istanbul ignore if */
-		if (optionsObj.debug) {
-			console.log(this.filePaths);
-		}
 	}
 	/**
 	 * Checks if a file is on the allowFiles list (aka the whitelist)

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -454,6 +454,51 @@ function statPromise(filePath) {
 	});
 }
 
+/**
+ * Replaces any root level values on an object that are 0, with a different value
+ * @param {object} inputObj  - The object to replace zeros on
+ * @param {any} replacement - what to replace the zeros with
+ * @returns {object} The object with zeros replaced
+ */
+function replaceZeros(inputObj, replacement) {
+	const keys = Object.keys(inputObj);
+	for (let x = 0; x < keys.length; x++) {
+		if (inputObj[keys[x]] === 0) {
+			inputObj[keys[x]] = replacement;
+		}
+	}
+	return inputObj;
+}
+
+/**
+ * Test whether or not we are in a git initialized repo space / folder
+ * @param {string} [OPT_folder] - Optional: Folder to use as dir to check in
+ * @returns {boolean} Whether or not in git repo
+ */
+function getIsInGitRepo(OPT_folder) {
+	let executeInPath = __dirname;
+	if (typeof (OPT_folder) === 'string') {
+		executeInPath = path.normalize(OPT_folder);
+	}
+	try {
+		childProc.execSync(`git status`, {
+			cwd: executeInPath
+		});
+		return true;
+	} catch (error) {
+		return false;
+	}
+}
+
+/**
+ * Return whether or not a filepath is a relative path
+ * @param {string} filePath - Filepath to check
+ * @returns {boolean} - If it is, or is not, a relative path.
+ */
+function getIsRelativePath(filePath) {
+	return !path.isAbsolute(filePath);
+}
+
 // @todo this is probably going to need to be revised
 let projectRootPath = isInNodeModules() ? posixNormalize(path.normalize(`${__dirname}/../..`)) : posixNormalize(`${__dirname}`);
 const callerDir = posixNormalize(process.cwd());
@@ -466,46 +511,12 @@ const projectRootPathTrailingSlash = projectRootPath + '/';
 
 module.exports = {
 	posixNormalize,
-	/**
-	* Replaces any root level values on an object that are 0, with a different value
-	* @param {object} inputObj  - The object to replace zeros on
-	* @param {any} replacement - what to replace the zeros with
-	* @returns {object} The object with zeros replaced
-	*/
-	replaceZeros(inputObj, replacement) {
-		const keys = Object.keys(inputObj);
-		for (let x = 0; x < keys.length; x++) {
-			if (inputObj[keys[x]] === 0) {
-				inputObj[keys[x]] = replacement;
-			}
-		}
-		return inputObj;
-	},
-	/**
-	* Test whether or not we are in a git initialized repo space / folder
-	* @param {string} [OPT_folder] - Optional: Folder to use as dir to check in
-	* @returns {boolean} Whether or not in git repo
-	*/
-	getIsInGitRepo(OPT_folder) {
-		let executeInPath = __dirname;
-		if (typeof (OPT_folder) === 'string') {
-			executeInPath = path.normalize(OPT_folder);
-		}
-		try {
-			childProc.execSync(`git status`, {
-				cwd: executeInPath
-			});
-			return true;
-		} catch (error) {
-			return false;
-		}
-	},
+	replaceZeros,
+	getIsInGitRepo,
 	replaceInObj,
 	projectRootPath,
 	projectRootPathTrailingSlash,
-	getIsRelativePath(filePath) {
-		return !path.isAbsolute(filePath);
-	},
+	getIsRelativePath,
 	isInNodeModules,
 	validateOptions,
 	extractArrFromStr,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -424,7 +424,6 @@ function getKernelInfo() {
  * @returns {Promise<Buffer>} - Stdout buffer
  */
 function execPromise(cmdStr, options) {
-	const childProc = require('child_process');
 	return new Promise((resolve, reject) => {
 		childProc.exec(cmdStr, options, (error, stdout) => {
 			if (error) {

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ async function main(options, opt_cb) {
 	*/
 	if (filePaths.length > 0) {
 		// Add line break
-		console.log('Files queued up. Starting scrape...\n');
+		console.log(`${filePaths.length} files queued up. Starting scrape...\n`);
 	}
 	/**
 	 * @type {Array<Promise>}
@@ -74,6 +74,7 @@ async function main(options, opt_cb) {
 	filePaths.forEach((filePathMeta, index) => {
 		let currFullPath = filePathMeta.fullPath;
 		let currLocalPath = filePathMeta.relativeToProjRoot;
+		/* istanbul ignore if */
 		if (optionsObj.debug) {
 			// Nice progress indicator in console
 			const consoleMsg = `Starting scrape of date info for file #${index + 1} / ${filePaths.length} ---> ${currLocalPath}`;

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@
 
 const readline = require('readline');
 const fse = require('fs-extra');
+// @ts-ignore
+const packageInfo = require('../package.json');
 const {posixNormalize, getIsInGitRepo, validateOptions, lazyAreObjsSame} = require('./helpers');
 const {updateTimestampsCacheFile, getTimestampsFromFile} = require('./stamp-handler');
 const FilelistHandler = require('./filelist-handler');
@@ -10,9 +12,15 @@ const FilelistHandler = require('./filelist-handler');
 /**
 * Main - called by CLI and the main export
 * @param {InputOptions} options - input options
-* @returns {object} - Stamp or info object
+* @param {function} [opt_cb] - Optional callback
+* @returns {Promise<object>} - Stamp or info object
 */
-function main(options) {
+async function main(options, opt_cb) {
+	const perfTimings = {
+		start: (new Date()).getTime(),
+		stop: 0,
+		elapsed: 0
+	};
 	/* istanbul ignore if */
 	if (!getIsInGitRepo()) {
 		throw (new Error('Fatal Error: You are not in a git initialized project space! Please run git init.'));
@@ -20,6 +28,11 @@ function main(options) {
 	const optionsObj = validateOptions(options);
 	/* istanbul ignore if */
 	if (optionsObj.debug) {
+		console.log(`
+			=== Git Date Extractor, DEBUG=ON ===
+			                ${packageInfo.version}
+			====================================
+		`);
 		console.log(optionsObj);
 	}
 	/**
@@ -51,30 +64,48 @@ function main(options) {
 	*/
 	if (filePaths.length > 0) {
 		// Add line break
-		console.log('');
+		console.log('Files queued up. Starting scrape...\n');
 	}
-	for (let f = 0; f < filePaths.length; f++) {
-		let currFullPath = filePaths[f].fullPath;
-		let currLocalPath = filePaths[f].relativeToProjRoot;
-		// Nice progress indicator in console
-		const consoleMsg = `Scraping Date info for file #${f + 1} / ${filePaths.length} ---> ${currLocalPath}`;
-		if (process.stdout && readline) {
-			readline.clearLine(process.stdout, 0);
-			readline.cursorTo(process.stdout, 0, null);
-			process.stdout.write(consoleMsg);
-			// If this is the last loop, close out the line with a newline
-			if (f === filePaths.length - 1) {
-				process.stdout.write('\n');
+	/**
+	 * @type {Array<Promise>}
+	 */
+	const promiseQueue = [];
+
+	filePaths.forEach((filePathMeta, index) => {
+		let currFullPath = filePathMeta.fullPath;
+		let currLocalPath = filePathMeta.relativeToProjRoot;
+		if (optionsObj.debug) {
+			// Nice progress indicator in console
+			const consoleMsg = `Starting scrape of date info for file #${index + 1} / ${filePaths.length} ---> ${currLocalPath}`;
+			if (process.stdout && readline) {
+				readline.clearLine(process.stdout, 0);
+				readline.cursorTo(process.stdout, 0, null);
+				process.stdout.write(consoleMsg);
+				// If this is the last loop, close out the line with a newline
+				if (index === filePaths.length - 1) {
+					process.stdout.write('\n');
+				}
+			} else {
+				console.log(consoleMsg);
 			}
-		} else {
-			console.log(consoleMsg);
 		}
 		// Normalize path, force to posix style forward slash
 		currFullPath = posixNormalize(currFullPath);
 		currLocalPath = posixNormalize(currLocalPath);
-		// Update obj
-		timestampsCache[currLocalPath] = getTimestampsFromFile(currFullPath, timestampsCache, currLocalPath, optionsObj, false);
-	}
+
+		const asyncResolver = async () => {
+			const result = await getTimestampsFromFile(currFullPath, timestampsCache, currLocalPath, optionsObj, false);
+			// Update results object
+			timestampsCache[currLocalPath] = result;
+			return result;
+		};
+		promiseQueue.push(asyncResolver());
+	});
+
+	// Wait for all the files to be processed
+	await Promise.all(promiseQueue);
+
+	// Check if we need to write out results to disk
 	if (writeCacheFile) {
 		// Check for diff
 		if (!readCacheFileSuccess || !lazyAreObjsSame(readCacheFileContents, timestampsCache)) {
@@ -83,16 +114,28 @@ function main(options) {
 			console.log('Saving of timestamps file skipped - nothing changed');
 		}
 	}
+
+	// Check for callback
+	if (typeof (opt_cb) === 'function') {
+		opt_cb(timestampsCache);
+	}
+
+	perfTimings.stop = (new Date()).getTime();
+	perfTimings.elapsed = perfTimings.stop - perfTimings.start;
+	console.log(`Total execution time = ${(perfTimings.elapsed / 1000).toFixed(2)} seconds.`);
 	return timestampsCache;
 }
 
+/**
+* Wrapper around main
+* @param {InputOptions} options - input options
+* @param {function} [opt_cb] - Optional callback
+* @returns {Promise<object>} - stamp object or info obj
+*/
+async function getStamps(options, opt_cb) {
+	return main(options, opt_cb);
+}
+
 module.exports = {
-	/**
-	* Wrapper around main
-	* @param {InputOptions} options - input options
-	* @returns {object} - stamp object or info obj
-	*/
-	getStamps(options) {
-		return main(options);
-	}
+	getStamps
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,5 +1,3 @@
-/// <reference types="node"/>
-
 type GitCommitHook = "pre" | "post" | "none";
 
 interface StampObject {
@@ -30,7 +28,9 @@ interface InputOptions {
 	// What triggered the execution
 	gitCommitHook?: GitCommitHook,
 	// Project root
-	projectRootPath?: string
+	projectRootPath?: string,
+	// Debug
+	debug?: boolean
 }
 
 interface FinalizedOptions {


### PR DESCRIPTION
Rewrote a lot of synchronous stuff (`execSync`, `statSync`, etc.) to use Promise based async versions. This required a lot of changes in a lot of different spots.

Although the file iterator still uses some sync stuff, that is not a large bottleneck, and the changes brought in by this PR **significantly** improves the performance of this module.

Random testing showed, on average, about a 3-4x increase in speed. For example, going from over 16 seconds to process 50 files, down to around 4 seconds. Or from 37 seconds for 218 files, down to 15.

Most of the remaining hold up seems to be in Node's `spawn child_process` calls. Not sure there is much I can do to optimize this, but worth noting if in the future I want to take a crack at another round of performance improvements.

This will close #2.