### PR TITLE
fix(index.js): pass project root options to git fn

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ async function main(options, opt_cb) {
 		});
 	}
 	/* istanbul ignore if */
-	if (!getIsInGitRepo()) {
+	if (!getIsInGitRepo(optionsObj.projectRootPath)) {
 		throw (new Error('Fatal Error: You are not in a git initialized project space! Please run git init.'));
 	}
 	/**


### PR DESCRIPTION
Initial check wasn't using provided options for
project root causing the plugin to crash