### PR TITLE
Improve: Overhaul tests, export types, perf work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ dist
 isolate-*-v8.log
 *.clinic-*.html
 .clinic
+git-date-extractor*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ gittest
 __tests__/tempdir-*
 debug.txt
 *.0x
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __tests__/tempdir-*
 debug.txt
 *.0x
 dist
+isolate-*-v8.log
+*.clinic-*.html
+.clinic

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# git-date-extractor [![Build Status](https://travis-ci.org/joshuatz/git-date-extractor.svg?branch=master)](https://travis-ci.org/github/joshuatz/git-date-extractor) [![codecov](https://codecov.io/gh/joshuatz/git-date-extractor/badge.svg?branch=master)](https://codecov.io/gh/joshuatz/git-date-extractor?branch=master)  [![npm](https://img.shields.io/npm/v/git-date-extractor)](https://www.npmjs.com/package/git-date-extractor)
+# git-date-extractor [![Build Status](https://travis-ci.org/joshuatz/git-date-extractor.svg?branch=main)](https://travis-ci.org/github/joshuatz/git-date-extractor) [![codecov](https://codecov.io/gh/joshuatz/git-date-extractor/badge.svg?branch=main)](https://codecov.io/gh/joshuatz/git-date-extractor?branch=main)  [![npm](https://img.shields.io/npm/v/git-date-extractor)](https://www.npmjs.com/package/git-date-extractor)
 
 > Easily extract file dates based on git history, and optionally cache in a easy to parse JSON file.
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ outputFileGitAdd | gitAdd | If saving to file, should the file be `git add`'ed a
 files | file | Specific files to get timestamps for. These should either be full file paths (e.g. `C:\dir\file.txt`) or relative to root of the scanned dir | `string[] or string` | NA - if empty, script will scan entire dir
 onlyIn | dirs | Filter files by specific directory | `string[] or string` | NA
 blockFiles | blocklist | Block certain files from being tracked | `string[] or string` | NA
-allowFiles | whitelist | Exception list of filepaths that will override certain blocks.<br>See advanced examples section. | `string[] or string | NA
+allowFiles | approvelist | Exception list of filepaths that will override certain blocks.<br>See advanced examples section. | `string[] or string | NA
 gitCommitHook | git-stage | Use this if you are running this script on a git hook.<br>For example, use `post` and the script will append a new commit with the changed timestamp file. | `"pre"` or `"post"` or `"none"` | `"none"`
 projectRootPath | rootDir | Top level directory containing your files.<br>Script should be able to detect automatically, but can also pass to be safe. | `string` | Auto-detected based on `proccess.cwd()`<br>or `__dirname`
 debug | debug | Might output extra meta info related to the development of this module | `boolean` | `false`
@@ -163,7 +163,7 @@ Setting `files` makes it run the fastest, since then it doesn't need to scan for
 
 However, here are some more advanced examples:
 
-### Allowing exceptions to files not in whitelisted directories
+### Allowing exceptions to files not in the approved directories
 Here is our example structure:
 - `alpha.txt`
 - `bravo.txt`

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -1,0 +1,45 @@
+const test = require('ava').default;
+const {makeTempDir, buildTestDir, testForStampInResults} = require('../tst-helpers');
+
+const childProc = require('child_process');
+const fse = require('fs-extra');
+const {posixNormalize} = require('../src/helpers');
+
+/** @type {string} */
+let tempDirPath;
+/** @type {import('../src/types').UnpackedPromise<ReturnType<typeof buildTestDir>>} */
+let builderRes;
+
+const CLI_CALL_PATH = posixNormalize(`${__dirname}/../src/cli.js`);
+
+test.before(async () => {
+	tempDirPath = await makeTempDir();
+	builderRes = await buildTestDir(tempDirPath, true);
+});
+
+test.after.always(async () => {
+	await fse.remove(tempDirPath);
+});
+
+test('CLI Test, Auto-Detection of Project Directory', async t => {
+	const outputFileName = 'explicit-stamps.json';
+	const consoleOut = childProc.execSync(`node ${CLI_CALL_PATH} --outputToFile --outputFileName ${outputFileName}`, {
+		cwd: tempDirPath,
+		encoding: 'utf8'
+	}).toString();
+	t.regex(consoleOut, /Total execution time/mi);
+	// Check JSON output
+	const parsedJson = await fse.readJSON(`${tempDirPath}/${outputFileName}`);
+	testForStampInResults(t, builderRes.testFilesRelative, parsedJson, [builderRes.testFilesRelative[".dotdir"].foxtrot]);
+});
+
+test('CLI Test, Explicit Project Directory', async t => {
+	const outputFileName = 'detection-stamps.json';
+	const consoleOut = childProc.execSync(`node ${CLI_CALL_PATH} --projectRootPath ${tempDirPath} --outputToFile --outputFileName ${outputFileName}`, {
+		encoding: 'utf8'
+	}).toString();
+	t.regex(consoleOut, /Total execution time/mi);
+	// Check JSON output
+	const parsedJson = await fse.readJSON(`${tempDirPath}/${outputFileName}`);
+	testForStampInResults(t, builderRes.testFilesRelative, parsedJson, [builderRes.testFilesRelative[".dotdir"].foxtrot]);
+});

--- a/__tests__/filelist-handler.test.js
+++ b/__tests__/filelist-handler.test.js
@@ -1,34 +1,34 @@
 const test = require('ava').default;
-const path = require('path');
 const fse = require('fs-extra');
 const FilelistHandler = require('../src/filelist-handler');
-const {replaceInObj, validateOptions, posixNormalize} = require('../src/helpers');
-const {getTestFilePaths, buildDir} = require('../src/tst-helpers');
+const {validateOptions} = require('../src/helpers');
+const {makeTempDir, buildTestDir} = require('../tst-helpers');
 
-// Set up some paths for testing
-// Test folder will be built in project root to avoid auto-filter based on __tests__ dirname
-const tempDirName = 'tempdir-filehandler';
-const tempDirPath = posixNormalize(__dirname + '/../' + tempDirName);
-const tempSubDirName = 'subdir';
-const tempSubDirPath = `${tempDirPath}/${tempSubDirName}`;
-const projectRootPathTrailingSlash = tempDirPath + '/';
+/**
+ * @typedef {ReturnType<typeof import('../tst-helpers')['getTestFilePaths']>} TestFilePaths
+ */
 
-const testFiles = getTestFilePaths(tempDirPath);
-
-const testFilesRelative = replaceInObj(testFiles, function(filePath) {
-	return path.normalize(filePath).replace(path.normalize(projectRootPathTrailingSlash), '');
-});
+/** @type {string} */
+let tempDirPath;
+/** @type {string} */
+let tempSubDirPath;
+/** @type {TestFilePaths} */
+let testFiles;
+/** @type {TestFilePaths} */
+let testFilesRelative;
 
 // Create directory and files for testing
-test.before(() => {
-	buildDir(tempDirPath, testFiles);
+test.before(async () => {
+	tempDirPath = await makeTempDir();
+	tempSubDirPath = `${tempDirPath}/subdir`;
+	const builderRes = await buildTestDir(tempDirPath, true);
+	testFilesRelative = builderRes.testFilesRelative;
+	testFiles = builderRes.testFiles;
 });
 
 // Teardown dir and files
 test.after.always(async () => {
-	// Just delete the top leve dir
-	await fse.emptyDir(tempDirPath);
-	await fse.rmdir(tempDirPath);
+	await fse.remove(tempDirPath);
 });
 
 test('Restricting files by directory (onlyIn)', t => {
@@ -45,11 +45,11 @@ test('Restricting files by directory (onlyIn)', t => {
 	const instance = new FilelistHandler(validateOptions(dummyOptions));
 	const expected = [
 		{
-			fullPath: path.normalize(testFiles.subdir.delta),
+			fullPath: testFiles.subdir.delta,
 			relativeToProjRoot: testFilesRelative.subdir.delta
 		},
 		{
-			fullPath: path.normalize(testFiles.subdir.echo),
+			fullPath: testFiles.subdir.echo,
 			relativeToProjRoot: testFilesRelative.subdir.echo
 		}
 	];
@@ -72,15 +72,15 @@ test('Restrict by directory + allowFiles override', t => {
 	const instance = new FilelistHandler(validateOptions(dummyOptions));
 	const expected = [
 		{
-			fullPath: path.normalize(testFiles.alpha),
+			fullPath: testFiles.alpha,
 			relativeToProjRoot: testFilesRelative.alpha
 		},
 		{
-			fullPath: path.normalize(testFiles.subdir.delta),
+			fullPath: testFiles.subdir.delta,
 			relativeToProjRoot: testFilesRelative.subdir.delta
 		},
 		{
-			fullPath: path.normalize(testFiles.subdir.echo),
+			fullPath: testFiles.subdir.echo,
 			relativeToProjRoot: testFilesRelative.subdir.echo
 		}
 	];
@@ -102,15 +102,15 @@ test('Restricting files by explicit file list', t => {
 	const instance = new FilelistHandler(validateOptions(dummyOptions));
 	const expected = [
 		{
-			fullPath: path.normalize(testFiles.alpha),
+			fullPath: testFiles.alpha,
 			relativeToProjRoot: testFilesRelative.alpha
 		},
 		{
-			fullPath: path.normalize(testFiles.subdir.delta),
+			fullPath: testFiles.subdir.delta,
 			relativeToProjRoot: testFilesRelative.subdir.delta
 		},
 		{
-			fullPath: path.normalize(testFiles.subdir.echo),
+			fullPath: testFiles.subdir.echo,
 			relativeToProjRoot: testFilesRelative.subdir.echo
 		}
 	];
@@ -131,23 +131,23 @@ test('Testing automatic dir parsing and filtering, + block list', t => {
 	const instance = new FilelistHandler(validateOptions(dummyOptions));
 	const expected = [
 		{
-			fullPath: path.normalize(testFiles.bravo),
+			fullPath: testFiles.bravo,
 			relativeToProjRoot: testFilesRelative.bravo
 		},
 		{
-			fullPath: path.normalize(testFiles.space),
+			fullPath: testFiles.space,
 			relativeToProjRoot: testFilesRelative.space
 		},
 		{
-			fullPath: path.normalize(testFiles.specialChars),
+			fullPath: testFiles.specialChars,
 			relativeToProjRoot: testFilesRelative.specialChars
 		},
 		{
-			fullPath: path.normalize(testFiles.subdir.delta),
+			fullPath: testFiles.subdir.delta,
 			relativeToProjRoot: testFilesRelative.subdir.delta
 		},
 		{
-			fullPath: path.normalize(testFiles.subdir.echo),
+			fullPath: testFiles.subdir.echo,
 			relativeToProjRoot: testFilesRelative.subdir.echo
 		}
 	];

--- a/__tests__/filelist-handler.test.js
+++ b/__tests__/filelist-handler.test.js
@@ -1,5 +1,3 @@
-/// <reference path="../types.d.ts"/>
-// @ts-check
 const test = require('ava').default;
 const path = require('path');
 const fse = require('fs-extra');
@@ -35,7 +33,7 @@ test.after.always(async () => {
 
 test('Restricting files by directory (onlyIn)', t => {
 	/**
-	 * @type {InputOptions}
+	 * @type {import('../src/types').InputOptions}
 	 */
 	const dummyOptions = {
 		onlyIn: [tempSubDirPath],
@@ -61,7 +59,7 @@ test('Restricting files by directory (onlyIn)', t => {
 test('Restrict by directory + allowFiles override', t => {
 	// Without the use of allowFiles, normally alpha.txt would be blocked by the onlyIn option, since it is not in the subdir
 	/**
-	 * @type {InputOptions}
+	 * @type {import('../src/types').InputOptions}
 	 */
 	const dummyOptions = {
 		onlyIn: [tempSubDirPath],
@@ -91,7 +89,7 @@ test('Restrict by directory + allowFiles override', t => {
 
 test('Restricting files by explicit file list', t => {
 	/**
-	 * @type {InputOptions}
+	 * @type {import('../src/types').InputOptions}
 	 */
 	const dummyOptions = {
 		onlyIn: [],
@@ -121,7 +119,7 @@ test('Restricting files by explicit file list', t => {
 
 test('Testing automatic dir parsing and filtering, + block list', t => {
 	/**
-	 * @type {InputOptions}
+	 * @type {import('../src/types').InputOptions}
 	 */
 	const dummyOptions = {
 		onlyIn: [],

--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -1,6 +1,6 @@
-// @ts-check
 const test = require('ava').default;
 const helpers = require('../src/helpers');
+
 /**
 * Helpers testing
 */
@@ -79,7 +79,7 @@ test('isInNodeModules', t => {
 
 test('Option validator', t => {
 	/**
-	 * @type {InputOptions}
+	 * @type {import('../src/types').InputOptions}
 	 */
 	const dummyOptions = {
 		files: '[alpha.txt, bravo.txt]',

--- a/__tests__/helpers.test.js
+++ b/__tests__/helpers.test.js
@@ -50,6 +50,7 @@ test('replaceInObj', t => {
 			}
 		}
 	};
+	/** @param {string | number} input */
 	const replacer = function(input) {
 		if (typeof (input) === 'string') {
 			return input.toLowerCase();

--- a/__tests__/jsconfig.json
+++ b/__tests__/jsconfig.json
@@ -1,0 +1,6 @@
+// This seems to be necessary, since root tsconfig.json does not include this directory to avoid compiling it to /dist
+{
+	"compilerOptions": {
+		"checkJs": true
+	}
+}

--- a/__tests__/jsconfig.json
+++ b/__tests__/jsconfig.json
@@ -1,6 +1,7 @@
 // This seems to be necessary, since root tsconfig.json does not include this directory to avoid compiling it to /dist
 {
 	"compilerOptions": {
-		"checkJs": true
+		"checkJs": true,
+		"noImplicitAny": true
 	}
 }

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -87,7 +87,7 @@ test('main - integration test - git post commit', async t => {
 	const timeDelay = Number(alphaStamp.modified) - Number(alphaStamp.created);
 	// Assume a small variance is OK
 	const timeDiff = Math.abs((Math.floor(checkTimeDelayMs / 1000)) - timeDelay);
-	t.true(timeDiff <= maxTimeVarianceSec, `Diff between created and modified should have been ${Math.floor(checkTimeDelayMs / 1000)}, but was ${timeDelay}. This variance of ${timeDiff} is beyond the accepted variance of ${maxTimeVarianceSec}.`);
+	t.true(timeDiff <= maxTimeVarianceSec, `Diff between created and modified should have been ${Math.floor(checkTimeDelayMs / 1000)}, but was ${timeDelay}. This variance of ${timeDiff} is beyond the accepted variance of ${maxTimeVarianceSec} (In ${tempDirPath}).`);
 });
 
 test('main - integration test - git pre commit', async t => {
@@ -151,7 +151,7 @@ test('main - integration test - git pre commit', async t => {
 		// Check time difference in stamps. Note that both modified and created stamps should be based off file stat, since no git history has been created
 		const timeDelay = Number(alphaStamp.modified) - Number(alphaStamp.created);
 		const timeDiff = Math.abs((Math.floor(checkTimeDelayMs / 1000)) - timeDelay);
-		t.true(timeDiff <= maxTimeVarianceSec, `Diff between created and modified should have been ${Math.floor(checkTimeDelayMs / 1000)}, but was ${timeDelay}. This variance of ${timeDiff} is beyond the accepted variance of ${maxTimeVarianceSec}.`);
+		t.true(timeDiff <= maxTimeVarianceSec, `Diff between created and modified should have been ${Math.floor(checkTimeDelayMs / 1000)}, but was ${timeDelay}. This variance of ${timeDiff} is beyond the accepted variance of ${maxTimeVarianceSec} (In ${tempDirPath}).`);
 	}
 });
 
@@ -163,7 +163,6 @@ test.serial.after.always(async () => {
 	}
 	iDebugLog(perfTimings);
 	await Promise.all(tempDirPaths.map(p => {
-		iDebugLog(`Cleaning up - deleting ${p}`);
 		return fse.remove(p);
 	}));
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,18 +1,15 @@
 const test = require('ava').default;
-const {iDebugLog} = require('../src/tst-helpers');
+const {iDebugLog, makeTempDir, buildTestDir, wasLastCommitAutoAddCache, testForStampInResults, touchFileSync} = require('../tst-helpers');
 
 const childProc = require('child_process');
 const fse = require('fs-extra');
 const main = require('../src');
 const {posixNormalize, getKernelInfo, getSemverInfo} = require('../src/helpers');
-const tstHelpers = require('../src/tst-helpers');
 
 // Set up some paths for testing
 const cacheFileName = 'cache.json';
-const tempDirNames = {
-	mainPostTest: 'tempdir-main-post',
-	mainPreTest: 'tempdir-main-pre'
-};
+/** @type {string[]} */
+const tempDirPaths = [];
 
 // Max variance for time diff
 const maxTimeVarianceSec = 2;
@@ -36,10 +33,10 @@ const perfTimings = {
  */
 test('main - integration test - git post commit', async t => {
 	// Create test dir
-	const tempDirName = tempDirNames.mainPostTest;
-	const tempDirPath = posixNormalize(__dirname + '/' + tempDirName);
+	const tempDirPath = await makeTempDir();
+	tempDirPaths.push(tempDirPath);
 	const cacheFilePath = posixNormalize(`${tempDirPath}/${cacheFileName}`);
-	const {testFiles, testFilesNamesOnly} = tstHelpers.buildTestDir(tempDirPath, true);
+	const {testFiles, testFilesNamesOnly} = await buildTestDir(tempDirPath, true);
 	const checkTimeDelayMs = 5000;
 	// Git add the files, since we are emulating a post commit
 	childProc.execSync('git add . && git commit -m "added files"', {
@@ -52,7 +49,7 @@ test('main - integration test - git post commit', async t => {
 		}, checkTimeDelayMs);
 	}));
 	// Touch alpha so it can be re-staged and committed - thus giving it a later modification stamp
-	tstHelpers.touchFileSync(testFiles.alpha, true);
+	touchFileSync(testFiles.alpha, true);
 	// Git commit all the files
 	childProc.execSync('git add . && git commit -m "added files"', {
 		cwd: tempDirPath
@@ -72,15 +69,15 @@ test('main - integration test - git post commit', async t => {
 	const result = await main.getStamps(dummyOptions);
 	perfTimings.postCommit.stop = (new Date()).getTime();
 	const savedResult = JSON.parse(fse.readFileSync(cacheFilePath).toString());
+
 	// Check that the value passed back via JS matches what was saved to JSON
 	t.deepEqual(result, savedResult);
 	// Check that last commit was from self
-	t.truthy(tstHelpers.wasLastCommitAutoAddCache(tempDirPath, cacheFileName));
+	t.truthy(wasLastCommitAutoAddCache(tempDirPath, cacheFileName));
 
 	// Check that actual numbers came back for stamps for files,
 	// but ignore .dotdir, as those are blocked by default
-	delete testFilesNamesOnly['.dotdir'];
-	tstHelpers.testForStampInResults(t, testFilesNamesOnly, result);
+	testForStampInResults(t, testFilesNamesOnly, result, [testFilesNamesOnly[".dotdir"].foxtrot]);
 
 	// Check a specific file stamp to verify it makes sense
 	const alphaStamp = result['alpha.txt'];
@@ -95,9 +92,9 @@ test('main - integration test - git post commit', async t => {
 
 test('main - integration test - git pre commit', async t => {
 	// Create test dir
-	const tempDirName = tempDirNames.mainPreTest;
-	const tempDirPath = posixNormalize(__dirname + '/' + tempDirName);
-	const {testFiles} = tstHelpers.buildTestDir(tempDirPath, true, cacheFileName);
+	const tempDirPath = await makeTempDir();
+	tempDirPaths.push(tempDirPath);
+	const {testFiles} = await buildTestDir(tempDirPath, true, cacheFileName);
 	const checkTimeDelayMs = 8000;
 	// Wait a bit so that we can make sure there is a difference in stamps
 	await (new Promise((resolve) => {
@@ -106,7 +103,7 @@ test('main - integration test - git pre commit', async t => {
 		}, checkTimeDelayMs);
 	}));
 	// Touch alpha so that it will have a different mtime value
-	tstHelpers.touchFileSync(testFiles.alpha, true);
+	touchFileSync(testFiles.alpha, true);
 	// Now run full process - get stamps, save to file, etc.
 	/**
 	 * @type {import('../src/types').InputOptions}
@@ -123,7 +120,7 @@ test('main - integration test - git pre commit', async t => {
 	const result = await main.getStamps(dummyOptions);
 	perfTimings.preCommit.stop = (new Date()).getTime();
 	// Now the cache file should be *staged* but **not** committed, since we used `pre`
-	t.falsy(tstHelpers.wasLastCommitAutoAddCache(tempDirPath, cacheFileName));
+	t.falsy(wasLastCommitAutoAddCache(tempDirPath, cacheFileName));
 	// Check that actual numbers came back for stamps
 	const alphaStamp = result['alpha.txt'];
 	t.true(typeof (alphaStamp.created) === 'number');
@@ -160,14 +157,13 @@ test('main - integration test - git pre commit', async t => {
 
 // Teardown dir and files
 test.serial.after.always(async () => {
-	for (const key in perfTimings) {
+	for (const k in perfTimings) {
+		const key = /** @type {keyof typeof perfTimings} */ (k);
 		perfTimings[key].elapsed = perfTimings[key].stop - perfTimings[key].start;
 	}
 	iDebugLog(perfTimings);
-	const dirNames = Object.keys(tempDirNames).map(key => tempDirNames[key]);
-	for (let x = 0; x < dirNames.length; x++) {
-		const tempDirPath = posixNormalize(__dirname + '/' + dirNames[x]);
-		// eslint-disable-next-line no-await-in-loop
-		await tstHelpers.removeTestDir(tempDirPath);
-	}
+	await Promise.all(tempDirPaths.map(p => {
+		iDebugLog(`Cleaning up - deleting ${p}`);
+		return fse.remove(p);
+	}));
 });

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,5 +1,5 @@
 const test = require('ava').default;
-const {iDebugLog, makeTempDir, buildTestDir, wasLastCommitAutoAddCache, testForStampInResults, touchFileSync} = require('../tst-helpers');
+const {iDebugLog, makeTempDir, buildTestDir, wasLastCommitAutoAddCache, testForStampInResults, touchFileSync, delay} = require('../tst-helpers');
 
 const childProc = require('child_process');
 const fse = require('fs-extra');
@@ -43,11 +43,7 @@ test('main - integration test - git post commit', async t => {
 		cwd: tempDirPath
 	});
 	// Wait a bit so that we can make sure there is a difference in stamps
-	await (new Promise((resolve) => {
-		setTimeout(() => {
-			resolve();
-		}, checkTimeDelayMs);
-	}));
+	await delay(checkTimeDelayMs);
 	// Touch alpha so it can be re-staged and committed - thus giving it a later modification stamp
 	touchFileSync(testFiles.alpha, true);
 	// Git commit all the files
@@ -97,11 +93,7 @@ test('main - integration test - git pre commit', async t => {
 	const {testFiles} = await buildTestDir(tempDirPath, true, cacheFileName);
 	const checkTimeDelayMs = 8000;
 	// Wait a bit so that we can make sure there is a difference in stamps
-	await (new Promise((resolve) => {
-		setTimeout(() => {
-			resolve();
-		}, checkTimeDelayMs);
-	}));
+	await delay(checkTimeDelayMs);
 	// Touch alpha so that it will have a different mtime value
 	touchFileSync(testFiles.alpha, true);
 	// Now run full process - get stamps, save to file, etc.
@@ -156,7 +148,7 @@ test('main - integration test - git pre commit', async t => {
 });
 
 // Teardown dir and files
-test.serial.after.always(async () => {
+test.after.always(async () => {
 	for (const k in perfTimings) {
 		const key = /** @type {keyof typeof perfTimings} */ (k);
 		perfTimings[key].elapsed = perfTimings[key].stop - perfTimings[key].start;

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -1,4 +1,3 @@
-// @ts-check
 const test = require('ava').default;
 const {iDebugLog} = require('../src/tst-helpers');
 
@@ -61,7 +60,7 @@ test('main - integration test - git post commit', async t => {
 	// Now run full process - get stamps, save to file, etc.
 	perfTimings.postCommit.start = (new Date()).getTime();
 	/**
-	 * @type {InputOptions}
+	 * @type {import('../src/types').InputOptions}
 	 */
 	const dummyOptions = {
 		projectRootPath: tempDirPath,
@@ -110,7 +109,7 @@ test('main - integration test - git pre commit', async t => {
 	tstHelpers.touchFileSync(testFiles.alpha, true);
 	// Now run full process - get stamps, save to file, etc.
 	/**
-	 * @type {InputOptions}
+	 * @type {import('../src/types').InputOptions}
 	 */
 	const dummyOptions = {
 		projectRootPath: tempDirPath,

--- a/__tests__/stamp-handler.test.js
+++ b/__tests__/stamp-handler.test.js
@@ -1,32 +1,35 @@
 const test = require('ava').default;
 const childProc = require('child_process');
 const fse = require('fs-extra');
+const main = require('../src');
 const stHandler = require('../src/stamp-handler');
 const {validateOptions} = require('../src/helpers');
-const {wasLastCommitAutoAddCache, makeTempDir} = require('../tst-helpers');
+const {wasLastCommitAutoAddCache, makeTempDir, buildTestDir, delay} = require('../tst-helpers');
 
-// Set up some paths for testing
-/** @type {string} */
-let tempDirPath;
-const cacheFileName = 'cache.json';
-/** @type {string} */
-let cacheFilePath;
+/** @type {string[]} */
+const createdTempDirPaths = [];
 
-// Create test files
-test.before(async () => {
-	tempDirPath = await makeTempDir();
-	cacheFilePath = `${tempDirPath}/${cacheFileName}`;
+const setup = async (cacheFileName = 'cache.json') => {
+	const tempDirPath = await makeTempDir();
+	createdTempDirPaths.push(tempDirPath);
+	const cacheFilePath = `${tempDirPath}/${cacheFileName}`;
 	// Git init - will fail if git is not installed
 	childProc.execSync(`git init`, {
 		cwd: tempDirPath
 	});
 	// Create JSON cacheFile
 	const cacheObj = {};
-	fse.createFileSync(cacheFilePath);
-	fse.writeFileSync(cacheFilePath, JSON.stringify(cacheObj, null, 2));
-});
+	await fse.createFile(cacheFilePath);
+	await fse.writeFile(cacheFilePath, JSON.stringify(cacheObj, null, 2));
+	return {
+		tempDirPath,
+		cacheFilePath,
+		cacheFileName
+	};
+};
 
-test.serial('save cache file', t => {
+test('Update cache file and auto-commit', async (t) => {
+	const {tempDirPath, cacheFilePath, cacheFileName} = await setup();
 	const nowStamp = (new Date()).getTime();
 	// Save without touching git
 	const cacheObj = {
@@ -41,23 +44,69 @@ test.serial('save cache file', t => {
 	 */
 	const dummyOptions = {
 		files: [],
+		// Note the use of "post" for gitCommitHook
+		// This should trigger adding of the cache file to the commit
 		gitCommitHook: 'post',
 		projectRootPath: tempDirPath,
 		outputToFile: true
 	};
 	stHandler.updateTimestampsCacheFile(cacheFilePath, cacheObj, validateOptions(dummyOptions));
 	// Now read back the file and check
-	const saved = JSON.parse(fse.readFileSync(cacheFilePath).toString());
+	const saved = await fse.readJSON(cacheFilePath);
 	t.deepEqual(cacheObj, saved);
-});
 
-test.serial('cache file git commmit', t => {
 	// Check that the file was checked into git
 	t.truthy(wasLastCommitAutoAddCache(tempDirPath, cacheFileName));
 });
 
+test('Reuse timestamps from cache file when possible', async (t) => {
+	const {tempDirPath, cacheFilePath, cacheFileName} = await setup();
+	const {testFilesRelative} = await buildTestDir(tempDirPath, false, cacheFileName);
+	const startTimeSec = Math.floor((new Date().getTime()) / 1000);
+	// Add a cache stamp for alpha, with a creation date wayyyy in the past
+	const fakeAlphaCreated = 100;
+	// File that is outside of test set; should be left alone
+	const nonTestingFileName = 'dont-modify-me.gif';
+	const fakeNonsenseStamp = -100;
+	/** @type {import('../src/types').StampCache} */
+	const dummyCache = {
+		[testFilesRelative.alpha]: {
+			created: fakeAlphaCreated,
+			modified: fakeAlphaCreated
+		},
+		[nonTestingFileName]: {
+			created: fakeNonsenseStamp,
+			modified: fakeNonsenseStamp
+		}
+	};
+	await fse.writeJSON(cacheFilePath, dummyCache);
+	/**
+	 * @type {import('../src/types').InputOptions}
+	 */
+	const dummyOptions = {
+		files: [],
+		projectRootPath: tempDirPath,
+		outputToFile: true,
+		outputFileName: cacheFileName
+	};
+	await delay(1000);
+	const result = await main.getStamps(dummyOptions);
+	/** @type {import('../src/types').StampCache} */
+	const saved = await fse.readJSON(cacheFilePath);
+	// Make sure that alpha.created was preserved in both JS result and saved file
+	t.true(result[testFilesRelative.alpha].created === fakeAlphaCreated);
+	t.true(saved[testFilesRelative.alpha].created === fakeAlphaCreated);
+	// But, alpha should be updated
+	t.true(result[testFilesRelative.alpha].modified !== fakeAlphaCreated);
+	t.true(result[testFilesRelative.alpha].modified > (startTimeSec - 10));
+	// And, file outside our set should have been left alone
+	t.true(saved[nonTestingFileName].created === fakeNonsenseStamp);
+	t.true(saved[nonTestingFileName].modified === fakeNonsenseStamp);
+});
+
 // Teardown - delete test files
-test.after.always(() => {
-	fse.emptyDirSync(tempDirPath);
-	fse.rmdirSync(tempDirPath);
+test.after.always(async () => {
+	await Promise.all(createdTempDirPaths.map(p => {
+		return fse.remove(p);
+	}));
 });

--- a/__tests__/stamp-handler.test.js
+++ b/__tests__/stamp-handler.test.js
@@ -3,17 +3,19 @@ const childProc = require('child_process');
 const fse = require('fs-extra');
 const stHandler = require('../src/stamp-handler');
 const {validateOptions} = require('../src/helpers');
-const {wasLastCommitAutoAddCache} = require('../src/tst-helpers');
+const {wasLastCommitAutoAddCache, makeTempDir} = require('../tst-helpers');
 
 // Set up some paths for testing
-const tempDirName = 'tempdir-stamphandler';
-const tempDirPath = __dirname + '/' + tempDirName;
+/** @type {string} */
+let tempDirPath;
 const cacheFileName = 'cache.json';
-const cacheFilePath = `${tempDirPath}/${cacheFileName}`;
+/** @type {string} */
+let cacheFilePath;
 
 // Create test files
-test.before(() => {
-	fse.ensureDirSync(tempDirPath);
+test.before(async () => {
+	tempDirPath = await makeTempDir();
+	cacheFilePath = `${tempDirPath}/${cacheFileName}`;
 	// Git init - will fail if git is not installed
 	childProc.execSync(`git init`, {
 		cwd: tempDirPath

--- a/__tests__/stamp-handler.test.js
+++ b/__tests__/stamp-handler.test.js
@@ -1,4 +1,3 @@
-// @ts-check
 const test = require('ava').default;
 const childProc = require('child_process');
 const fse = require('fs-extra');
@@ -36,7 +35,7 @@ test.serial('save cache file', t => {
 		}
 	};
 	/**
-	 * @type {InputOptions}
+	 * @type {import('../src/types').InputOptions}
 	 */
 	const dummyOptions = {
 		files: [],

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,0 +1,5 @@
+declare namespace NodeJS {
+	interface Global {
+		calledViaCLI?: boolean;
+	}
+}

--- a/package.json
+++ b/package.json
@@ -10,21 +10,23 @@
 		"url": "https://joshuatz.com/?utm_source=gitdateextractor&utm_medium=package"
 	},
 	"bin": {
-		"git-date-extractor": "src/cli.js",
-		"git-dates": "src/cli.js"
+		"git-date-extractor": "dist/cli.js",
+		"git-dates": "dist/cli.js"
 	},
-	"main": "src/index.js",
+	"main": "dist/index.js",
 	"engines": {
 		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo && nyc ava",
 		"lint": "xo",
-		"test-nolint": "nyc ava"
+		"test-nolint": "nyc ava",
+		"build": "rm -rf dist && tsc"
 	},
 	"files": [
-		"src/"
+		"dist/"
 	],
+	"types": "dist/index.d.ts",
 	"keywords": [
 		"cli-app",
 		"cli",
@@ -44,6 +46,7 @@
 		"ava": "^3.8.2",
 		"codecov": "^3.7.0",
 		"nyc": "^15.0.1",
+		"typescript": "^4.0.3",
 		"xo": "^0.25.4"
 	},
 	"nyc": {
@@ -74,7 +77,9 @@
 			"prefer-named-capture-group": "off"
 		},
 		"ignores": [
-			"**/*d.ts"
+			"**/*d.ts",
+			"src/types.ts",
+			"dist"
 		]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,16 @@
 	"version": "3.1.1",
 	"description": "Easily extract file dates based on git history, and optionally cache in a easy to parse JSON file.",
 	"license": "MIT",
-	"repository": "joshuatz/git-date-extractor",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/joshuatz/git-date-extractor.git"
+	},
+	"bugs": {
+		"url": "https://github.com/joshuatz/git-date-extractor/issues"
+	},
+	"homepage": "https://github.com/joshuatz/git-date-extractor",
 	"author": {
 		"name": "Joshua Tzucker",
-		"email": "joshua.tz@gmail.com",
 		"url": "https://joshuatz.com/?utm_source=gitdateextractor&utm_medium=package"
 	},
 	"bin": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
 		"test": "xo && nyc ava",
 		"lint": "xo",
 		"test-nolint": "nyc ava",
-		"build": "rm -rf dist && tsc"
+		"build": "rm -rf dist && tsc",
+		"tsc-check": "tsc --noEmit",
+		"benchmark": "node scripts/perf-stress-test.js"
 	},
 	"files": [
 		"dist/"

--- a/scripts/perf-stress-test.js
+++ b/scripts/perf-stress-test.js
@@ -1,0 +1,135 @@
+// @ts-check
+const {makeTempDir, iDebugLog} = require('../tst-helpers');
+const fse = require('fs-extra');
+const {posixNormalize} = require('../src/helpers');
+const childProc = require('child_process');
+const main = require('../src');
+
+const ROOT_FILE_COUNT = 120;
+// How many top-level subdirs to create
+const SUBDIR_ROOT_COUNT = 4;
+// Contents of top-level subdirs
+const SUBDIR_LEVELS = 3;
+const SUBDIR_FILE_COUNT = 20;
+const FILE_CONTENTS = `TEST FILE -- ⏱ --`;
+
+/** @type {string} */
+let tempDirPath;
+
+const perfInfo = {
+	testMeta: {
+		timeToCreateFilesMs: 0,
+		totalFileCount: 0
+	},
+	results: {
+		totalExecutionTimeMs: 0,
+		totalExecutionTimeSec: 0,
+		filesPerSec: 0
+	}
+};
+
+const timer = {
+	fileCreation: {
+		start: 0,
+		stop: 0
+	},
+	program: {
+		start: 0,
+		stop: 0
+	}
+};
+
+const getRandExtension = () => {
+	const extensions = ['txt', 'md', 'html'];
+	return extensions[Math.floor(Math.random() * extensions.length)];
+};
+
+const folderNames = ['alpha', 'bravo', 'charlie', 'delta'];
+const getRandFolderName = () => {
+	return folderNames[Math.floor(Math.random() * folderNames.length)];
+};
+
+/**
+ *
+ * @param {string} folderPath
+ * @param {number} num
+ */
+const getTestFilePath = (folderPath, num) => {
+	const slash = folderPath.endsWith('/') ? '' : '/';
+	return `${folderPath}${slash}t-${num}.${getRandExtension()}`;
+};
+
+const stressTest = async () => {
+	const filePaths = [];
+	timer.fileCreation.start = new Date().getTime();
+	tempDirPath = posixNormalize(await makeTempDir());
+	// Create root files
+	for (let x = 0; x < ROOT_FILE_COUNT; x++) {
+		filePaths.push(getTestFilePath(tempDirPath, x));
+	}
+	// Create subdir files
+	for (let x = 0; x < SUBDIR_ROOT_COUNT && x < folderNames.length; x++) {
+		const baseFolderName = folderNames[x];
+		for (let s = 1; s < SUBDIR_LEVELS; s++) {
+			const subDirPath = `${tempDirPath}/${baseFolderName}/${new Array(s).fill(0).map(getRandFolderName).join('/')}`;
+			for (let f = 0; f < SUBDIR_FILE_COUNT; f++) {
+				filePaths.push(getTestFilePath(subDirPath, f));
+			}
+		}
+	}
+
+	// Wait for all files to be created
+	await Promise.all(filePaths.map(async (p) => {
+		await fse.ensureFile(p);
+		await fse.writeFile(p, FILE_CONTENTS);
+	}));
+	timer.fileCreation.stop = new Date().getTime();
+	const totalFileCount = filePaths.length;
+	perfInfo.testMeta = {
+		timeToCreateFilesMs: timer.fileCreation.stop - timer.fileCreation.start,
+		totalFileCount
+	};
+
+	// Git init
+	childProc.execSync('git init', {
+		cwd: tempDirPath
+	});
+	childProc.execSync('git add . && git commit -m "Adding files"', {
+		cwd: tempDirPath
+	});
+
+	// Run program
+	timer.program.start = new Date().getTime();
+	/** @type {import('../src/types').InputOptions} */
+	const programOptions = {
+		projectRootPath: tempDirPath,
+		outputToFile: true
+	};
+	const result = await main.getStamps(programOptions);
+	timer.program.stop = new Date().getTime();
+
+	// Gather and return results
+	console.assert(Object.keys(result).length === totalFileCount, 'Something went wrong with file generation, or program; # of files with date info does not match # supposed to be generated');
+	const totalExecutionTimeMs = timer.program.stop - timer.program.start;
+	const totalExecutionTimeSec = totalExecutionTimeMs / 1000;
+	perfInfo.results = {
+		totalExecutionTimeMs,
+		totalExecutionTimeSec,
+		filesPerSec: totalFileCount / totalExecutionTimeSec
+	};
+	return perfInfo;
+};
+
+const teardown = async () => {
+	await fse.remove(tempDirPath);
+};
+
+const run = async() => {
+	const results = await stressTest();
+	iDebugLog(results);
+	await teardown();
+};
+
+run().then(() => {
+	console.log(`Done!`);
+});

--- a/src/cli.js
+++ b/src/cli.js
@@ -60,7 +60,7 @@ const cli = meow(`
 		},
 		allowFiles: {
 			type: 'string',
-			alias: 'whitelist'
+			alias: 'approvelist'
 		},
 		gitCommitHook: {
 			type: 'string',

--- a/src/filelist-handler.js
+++ b/src/filelist-handler.js
@@ -180,13 +180,18 @@ class FilelistHandler {
 			shouldBlock = true;
 		}
 		/* istanbul ignore if */
-		if (fse.lstatSync(filePath).isDirectory() === true) {
-			return false;
-		}
-		if (checkExists) {
-			if (fse.existsSync(filePath) === false) {
+		let exists = true;
+		try {
+			if (fse.lstatSync(filePath).isDirectory() === true) {
 				return false;
 			}
+			exists = true;
+		// eslint-disable-next-line no-unused-vars
+		} catch (error) {
+			exists = false;
+		}
+		if (checkExists && !exists) {
+			return false;
 		}
 		if (shouldBlock) {
 			// Let override with allowFiles

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -53,7 +53,8 @@ function _validateOptions(input) {
 		// Remove trailing slashes
 		moddedOptions.projectRootPath = moddedOptions.projectRootPath.replace(/[\/\\]{0,2}$/, '');
 	}
-	moddedOptions.projectRootPathTrailingSlash = moddedOptions.projectRootPath + '/';
+	moddedOptions.projectRootPath = posixNormalize(moddedOptions.projectRootPath);
+	moddedOptions.projectRootPathTrailingSlash = posixNormalize(moddedOptions.projectRootPath + '/');
 	if (typeof (moddedOptions.outputToFile) !== 'boolean') {
 		moddedOptions.outputToFile = false;
 	}
@@ -498,7 +499,6 @@ function getIsRelativePath(filePath) {
 // @todo this is probably going to need to be revised
 let projectRootPath = isInNodeModules() ? posixNormalize(path.normalize(`${__dirname}/../..`)) : posixNormalize(`${__dirname}`);
 const callerDir = posixNormalize(process.cwd());
-/* istanbul ignore if */
 if (projectRootPath.includes(posixNormalize(__dirname)) || projectRootPath.includes(callerDir) || global.calledViaCLI) {
 	projectRootPath = callerDir;
 }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,3 @@
-/// <reference path="../types.d.ts"/>
-// @ts-check
-'use strict';
-
 const path = require('path');
 const childProc = require('child_process');
 const os = require('os');
@@ -20,9 +16,10 @@ const posixNormalize = function(filePath) {
 /**
  * Extract an array from a stringified array
  * @param {string} str - input string
- * @returns {array} - Array output
+ * @returns {string[]} - Array output
  */
 function extractArrFromStr(str) {
+	/** @type {string[]} */
 	let arr = [];
 	if (typeof (str) === 'string') {
 		// Test for input string resembling array
@@ -41,7 +38,7 @@ function extractArrFromStr(str) {
 /**
  * Internal options validator / modder
  * @param {object} input - Options object
- * @returns {FinalizedOptions} - The finalized, formatted options
+ * @returns {import('./types').FinalizedOptions} - The finalized, formatted options
  */
 function _validateOptions(input) {
 	const moddedOptions = JSON.parse(JSON.stringify(input));
@@ -112,13 +109,13 @@ function _validateOptions(input) {
 
 /**
  * Validates input options and forces them to conform
- * @param {InputOptions} input - Options
- * @returns {FinalizedOptions} - The vaidated and formatted options
+ * @param {import('./types').InputOptions} input - Options
+ * @returns {import('./types').FinalizedOptions} - The vaidated and formatted options
  */
 function validateOptions(input) {
 	const moddedOptions = _validateOptions(input);
 	/**
-	 * @type {FinalizedOptions}
+	 * @type {import('./types').FinalizedOptions}
 	 */
 	const finalOptions = {
 		outputToFile: moddedOptions.outputToFile,
@@ -138,11 +135,12 @@ function validateOptions(input) {
 
 /**
  * Run a replacer function over an object to modify it
- * @param {object} inputObj - the object to replace values in
- * @param {function} replacerFunc - cb func to take value, modify, and return it
- * @returns {object} - Object with replacements
+ * @param {{[k: string]: any}} inputObj - the object to replace values in
+ * @param {(input: any) => any} replacerFunc - cb func to take value, modify, and return it
+ * @returns {{[k: string]: any}} - Object with replacements
  */
 function replaceInObj(inputObj, replacerFunc) {
+	/** @type {{[k: string]: any}} */
 	const outputObj = {};
 	for (let x = 0; x < Object.keys(inputObj).length; x++) {
 		const key = Object.keys(inputObj)[x];
@@ -243,8 +241,8 @@ function getHighest(numArr) {
 
 /**
  * Get the highest and lowest stamps from FS Stats
- * @param {object} stats - FS Stats object
- * @returns {object} - Highest and lowest points
+ * @param {import('fs').Stats} stats - FS Stats object
+ * @returns {{lowestMs: number, highestMs: number}} - Highest and lowest points
  */
 function getEndOfRangeFromStat(stats) {
 	const lowestMs = getLowest([
@@ -276,10 +274,11 @@ function getEndOfRangeFromStat(stats) {
  * Get the birth times of a file
  * @param {string} filePath - The filepath of the file to get birth of
  * @param {boolean} [preferNative] - Prefer using Node FS - don't try for debugfs
- * @param {object} [OPT_fsStats] - Stats object, if you already have it ready
+ * @param {import('fs-extra').Stats} [OPT_fsStats] - Stats object, if you already have it ready
  * @returns {Promise<BirthStamps>} - Birth stamps
  */
 async function getFsBirth(filePath, preferNative, OPT_fsStats) {
+	/** @type {BirthStamps} */
 	const birthStamps = {
 		birthtime: null,
 		birthtimeMs: null,
@@ -452,7 +451,7 @@ function statPromise(filePath) {
 
 /**
  * Replaces any root level values on an object that are 0, with a different value
- * @param {object} inputObj  - The object to replace zeros on
+ * @param {{[k: string]: any}} inputObj  - The object to replace zeros on
  * @param {any} replacement - what to replace the zeros with
  * @returns {object} The object with zeros replaced
  */

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -59,9 +59,12 @@ function _validateOptions(input) {
 		moddedOptions.outputToFile = false;
 	}
 	if (moddedOptions.outputToFile) {
+		// Default outputFileName
 		if (typeof (moddedOptions.outputFileName) !== 'string' || moddedOptions.outputFileName.length === 0) {
 			moddedOptions.outputFileName = 'timestamps.json';
 		}
+	}
+	if (typeof moddedOptions.outputFileName === 'string') {
 		// Force outputFile (e.g. the cache file) to a full path if it is not
 		if (!path.isAbsolute(moddedOptions.outputFileName)) {
 			moddedOptions.outputFileName = posixNormalize(`${moddedOptions.projectRootPath}/${moddedOptions.outputFileName}`);

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,7 @@ async function main(options, opt_cb) {
 }
 
 /**
-* Wrapper around main
+* Run the extractor with options
 * @param {import('./types').InputOptions} options - input options
 * @param {function} [opt_cb] - Optional callback
 * @returns {Promise<import('./types').StampCache>} - stamp object or info obj

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ async function main(options, opt_cb) {
 	}
 	/* istanbul ignore if */
 	if (!getIsInGitRepo(optionsObj.projectRootPath)) {
-		throw (new Error('Fatal Error: You are not in a git initialized project space! Please run git init.'));
+		throw (new Error(`Fatal Error: You are not in a git initialized project space! Please run git init in ${optionsObj.projectRootPath}.`));
 	}
 	/**
 	* @type {import('./types').StampCache}
@@ -47,15 +47,21 @@ async function main(options, opt_cb) {
 	// Load in cache if applicable
 	if (readCacheFile) {
 		if (fse.existsSync(optionsObj.outputFileName) === false) {
-			fse.writeFileSync(optionsObj.outputFileName, '{}');
+			if (optionsObj.debug) {
+				console.log(`Warning: Cache file ${optionsObj.outputFileName} does not already exist.`);
+			}
+			if (optionsObj.outputToFile) {
+				fse.writeFileSync(optionsObj.outputFileName, '{}');
+			}
 		} else {
 			try {
 				timestampsCache = JSON.parse(fse.readFileSync(optionsObj.outputFileName).toString());
 				readCacheFileSuccess = true;
+				// Lazy clone obj
 				readCacheFileContents = JSON.parse(JSON.stringify(timestampsCache));
 			// eslint-disable-next-line no-unused-vars
 			} catch (error) {
-				console.warn(`Could not read in cache file @ ${optionsObj.outputFileName}`);
+				console.log(`Warning: Could not read in cache file @ ${optionsObj.outputFileName}`);
 			}
 		}
 	}
@@ -113,6 +119,7 @@ async function main(options, opt_cb) {
 	}), optionsObj, timestampsCache, false);
 	// Update results object
 	timestampsCache = {
+		...timestampsCache,
 		...results
 	};
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const FilelistHandler = require('./filelist-handler');
 * Main - called by CLI and the main export
 * @param {import('./types').InputOptions} options - input options
 * @param {function} [opt_cb] - Optional callback
-* @returns {Promise<object>} - Stamp or info object
+* @returns {Promise<import('./types').StampCache>} - Stamp or info object
 */
 async function main(options, opt_cb) {
 	const perfTimings = {
@@ -133,7 +133,7 @@ async function main(options, opt_cb) {
 * Wrapper around main
 * @param {import('./types').InputOptions} options - input options
 * @param {function} [opt_cb] - Optional callback
-* @returns {Promise<object>} - stamp object or info obj
+* @returns {Promise<import('./types').StampCache>} - stamp object or info obj
 */
 async function getStamps(options, opt_cb) {
 	return main(options, opt_cb);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
-// @ts-check
 'use strict';
-
 const readline = require('readline');
 const fse = require('fs-extra');
 // @ts-ignore
@@ -11,7 +9,7 @@ const FilelistHandler = require('./filelist-handler');
 
 /**
 * Main - called by CLI and the main export
-* @param {InputOptions} options - input options
+* @param {import('./types').InputOptions} options - input options
 * @param {function} [opt_cb] - Optional callback
 * @returns {Promise<object>} - Stamp or info object
 */
@@ -39,7 +37,7 @@ async function main(options, opt_cb) {
 		throw (new Error('Fatal Error: You are not in a git initialized project space! Please run git init.'));
 	}
 	/**
-	* @type StampCache
+	* @type {import('./types').StampCache}
 	*/
 	let timestampsCache = {};
 	const readCacheFile = typeof (optionsObj.outputFileName) === 'string' && optionsObj.outputFileName.length > 0;
@@ -71,7 +69,7 @@ async function main(options, opt_cb) {
 		console.log(`${filePaths.length} files queued up. Starting scrape...\n`);
 	}
 	/**
-	 * @type {Array<Promise>}
+	 * @type {Array<Promise<any>>}
 	 */
 	const promiseQueue = [];
 
@@ -99,7 +97,7 @@ async function main(options, opt_cb) {
 		currLocalPath = posixNormalize(currLocalPath);
 
 		const asyncResolver = async () => {
-			const result = await getTimestampsFromFile(currFullPath, timestampsCache, currLocalPath, optionsObj, false);
+			const result = await getTimestampsFromFile(currFullPath, optionsObj, timestampsCache, currLocalPath, false);
 			// Update results object
 			timestampsCache[currLocalPath] = result;
 			return result;
@@ -133,7 +131,7 @@ async function main(options, opt_cb) {
 
 /**
 * Wrapper around main
-* @param {InputOptions} options - input options
+* @param {import('./types').InputOptions} options - input options
 * @param {function} [opt_cb] - Optional callback
 * @returns {Promise<object>} - stamp object or info obj
 */

--- a/src/stamp-handler.js
+++ b/src/stamp-handler.js
@@ -1,6 +1,6 @@
 const childProc = require('child_process');
 const fse = require('fs-extra');
-const {replaceZeros, getIsInGitRepo, getIsValidStampVal, getFsBirth, execPromise, statPromise} = require('./helpers');
+const {replaceZeros, getIsInGitRepo, getIsValidStampVal, getFsBirth, statPromise, spawnPromise, failSafePromise} = require('./helpers');
 
 /**
 * Updates the timestamp cache file and checks it into source control, depending on settings
@@ -41,82 +41,123 @@ function updateTimestampsCacheFile(cacheFilePath, jsonObj, optionsObj) {
 }
 
 /**
-* Get timestamps for a given file
-* @param {string} fullFilePath - The *full* file path to get stamps for
-* @param {import('./types').FinalizedOptions} optionsObj - Options
-* @param {import('./types').StampCache} [cache] - Object with key/pair values corresponding to valid stamps
-* @param {string} [cacheKey] - What is the stamp currently stored under for this file?
-* @param {boolean} [forceCreatedRefresh] - If true, any existing created stamps in cache will be ignored, and re-calculated
-* @returns {Promise<import('./types').StampObject>} - Timestamp object for file
-*/
-// eslint-disable-next-line max-params
-async function getTimestampsFromFile(fullFilePath, optionsObj, cache, cacheKey, forceCreatedRefresh) {
+ * @typedef {object} FileToCheckMeta
+ * @property {string} fullFilePath - The *full* file path to get stamps for
+ * @property {string} [cacheKey] - What is the stamp currently stored under for this file?
+ * @property {string} [resultKey] - If provided, will be the value used as the key in the results object. Default = fullFilePath
+ */
+
+/**
+ *
+ * @param {Array<FileToCheckMeta>} filesToGet - Files to retrieve stamps for
+ * @param {import('./types').FinalizedOptions} optionsObj - Options
+ * @param {import('./types').StampCache} [cache] - Object with key/pair values corresponding to valid stamps
+ * @param {boolean} [forceCreatedRefresh] If true, any existing created stamps in cache will be ignored, and re-calculated
+ */
+async function getTimestampsFromFilesBulk(filesToGet, optionsObj, cache, forceCreatedRefresh) {
 	const {gitCommitHook} = optionsObj;
 	const ignoreCreatedCache = typeof (forceCreatedRefresh) === 'boolean' ? forceCreatedRefresh : false;
 	const timestampsCache = typeof (cache) === 'object' ? cache : {};
-	/**
-	 * @type {object}
-	 */
+	/** @type {import('child_process').SpawnOptions} */
 	const execOptions = {
 		stdio: 'pipe',
 		cwd: optionsObj.projectRootPath
 	};
-	// Lookup values in cache
-	/**
-	* @type {import('./types').StampObject}
-	*/
-	let dateVals = timestampsCache[cacheKey];
-	dateVals = typeof (dateVals) === 'object' ? dateVals : {
-		created: 0,
-		modified: 0
-	};
-	try {
-		/* istanbul ignore else */
-		if (!dateVals.created || ignoreCreatedCache) {
-			// Get the created stamp by looking through log and following history
+
+	// Try to run things as concurrently as possible
+	/** @type {Array<Promise<{fileMeta: FileToCheckMeta,stamps: import('./types').StampObject}>>} */
+	const promiseArr = [];
+
+	for (let f = 0; f < filesToGet.length; f++) {
+		promiseArr.push((async () => {
+			const fileMeta = filesToGet[f];
+			const {fullFilePath, cacheKey} = fileMeta;
+			// Lookup values in cache
 			/**
-			* @type {any}
+			* @type {import('./types').StampObject}
 			*/
-			let createdStamp = (await execPromise(`git log --pretty=format:%at -- "${fullFilePath}" | tail -n 1`, execOptions)).toString();
-			createdStamp = Number(createdStamp);
-			if (!getIsValidStampVal(createdStamp) && gitCommitHook.toString() !== 'post') {
-				// During pre-commit, a file could be being added for the first time, so it wouldn't show up in the git log. We'll fall back to OS stats here
-				// createdStamp = Math.floor(fse.statSync(fullFilePath).birthtimeMs / 1000);
-				createdStamp = (await getFsBirth(fullFilePath)).birthtime;
+			let dateVals = timestampsCache[cacheKey];
+			dateVals = typeof (dateVals) === 'object' ? dateVals : {
+				created: 0,
+				modified: 0
+			};
+
+			try {
+				/* istanbul ignore else */
+				if (!dateVals.created || ignoreCreatedCache) {
+					// Get the created stamp by looking through log and following history
+					// Remember - for created, we want the very **first** commit, which in the git log, is actually the *oldest* and *last* commit
+
+					// NEED to either wrap with try/catch, or create helper utility to wrap any promise with return null if fail, etc.
+
+					let createdStamp = null;
+					const createdStampsLog = await failSafePromise(spawnPromise(`git`, [`log`, `--follow`, `--pretty=format:%at`, `--`, fullFilePath], execOptions), null);
+					if (createdStampsLog) {
+					// Need to basically run `tail -n 1`, grab last line
+						const createdStamps = createdStampsLog.split(/[\r\n]+/m);
+						createdStamp = Number(createdStamps[createdStamps.length - 1]);
+					}
+					if (!getIsValidStampVal(createdStamp) && gitCommitHook.toString() !== 'post') {
+						// During pre-commit, a file could be being added for the first time, so it wouldn't show up in the git log. We'll fall back to OS stats here
+						// createdStamp = Math.floor(fse.statSync(fullFilePath).birthtimeMs / 1000);
+						createdStamp = (await getFsBirth(fullFilePath)).birthtime;
+					}
+					if (Number.isNaN(createdStamp) === false) {
+						dateVals.created = createdStamp;
+					}
+				}
+
+				// Always update modified stamp regardless
+				let modifiedStamp = null;
+				if (gitCommitHook === 'none' || gitCommitHook === 'post') {
+					// If this is running after the commit that modified the file, we can use git log to pull the modified time out
+					// Modified should be the most recent and at the top of the log
+					modifiedStamp = await failSafePromise(spawnPromise(`git`, [`log`, `-1`, `--pretty=format:%at`, `--follow`, `--`, fullFilePath], execOptions), null);
+				}
+				modifiedStamp = Number(modifiedStamp);
+				if (gitCommitHook === 'pre' || !getIsValidStampVal(modifiedStamp)) {
+					// If this is running before the changed files have actually be commited, they either won't show up in the git log, or the modified time in the log will be from one commit ago, not the current
+					// Pull modified time from file itself
+					const fsStats = await statPromise(fullFilePath);
+					modifiedStamp = Math.floor(fsStats.mtimeMs / 1000);
+				}
+				if (Number.isNaN(modifiedStamp) === false) {
+					dateVals.modified = modifiedStamp;
+				}
+				// Check for zero values - this might be the case if there is no git history - new file
+				// If there is a zero, replace with current Unix stamp, but make sure to convert from JS MS to regular S
+				dateVals = replaceZeros(dateVals, Math.floor((new Date()).getTime() / 1000));
+			} catch (error) {
+				/* istanbul ignore next */
+				console.log(`getting git dates failed for ${fullFilePath}`);
+				/* istanbul ignore next */
+				console.error(error);
 			}
-			if (Number.isNaN(createdStamp) === false) {
-				dateVals.created = createdStamp;
-			}
-		}
-		// Always update modified stamp regardless
-		let modifiedStamp = null;
-		if (gitCommitHook === 'none' || gitCommitHook === 'post') {
-			// If this is running after the commit that modified the file, we can use git log to pull the modified time out
-			modifiedStamp = (await execPromise(`git log --pretty=format:%at --follow -- "${fullFilePath}" | sort | tail -n 1`, execOptions)).toString();
-		}
-		modifiedStamp = Number(modifiedStamp);
-		if (gitCommitHook === 'pre' || !getIsValidStampVal(modifiedStamp)) {
-			// If this is running before the changed files have actually be commited, they either won't show up in the git log, or the modified time in the log will be from one commit ago, not the current
-			// Pull modified time from file itself
-			const fsStats = await statPromise(fullFilePath);
-			modifiedStamp = Math.floor(fsStats.mtimeMs / 1000);
-		}
-		if (Number.isNaN(modifiedStamp) === false) {
-			dateVals.modified = modifiedStamp;
-		}
-		// Check for zero values - this might be the case if there is no git history - new file
-		// If there is a zero, replace with current Unix stamp, but make sure to convert from JS MS to regular S
-		dateVals = replaceZeros(dateVals, Math.floor((new Date()).getTime() / 1000));
-	} catch (error) {
-		/* istanbul ignore next */
-		console.log(`getting git dates failed for ${fullFilePath}`);
-		/* istanbul ignore next */
-		console.error(error);
+
+			return {
+				fileMeta,
+				stamps: dateVals
+			};
+		})());
 	}
-	return dateVals;
+	// Wait for all promises to resolve, combine results, indexed by full path
+	/**
+	 * @typedef {{[k: string]: import('./types').StampObject}} CombinedResults
+	 */
+	/** @type {CombinedResults} */
+	let combinedResults = {};
+	const results = await Promise.all(promiseArr);
+
+	combinedResults = results.reduce((running, curr) => {
+		const key = curr.fileMeta.resultKey || curr.fileMeta.fullFilePath;
+		running[key] = curr.stamps;
+		return running;
+	}, combinedResults);
+
+	return combinedResults;
 }
 
 module.exports = {
 	updateTimestampsCacheFile,
-	getTimestampsFromFile
+	getTimestampsFromFilesBulk
 };

--- a/src/stamp-handler.js
+++ b/src/stamp-handler.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 const childProc = require('child_process');
 const fse = require('fs-extra');
 const {replaceZeros, getIsInGitRepo, getIsValidStampVal, getFsBirth, execPromise, statPromise} = require('./helpers');
@@ -8,7 +6,7 @@ const {replaceZeros, getIsInGitRepo, getIsValidStampVal, getFsBirth, execPromise
 * Updates the timestamp cache file and checks it into source control, depending on settings
 * @param {string} cacheFilePath - the path of the files to save the cache out to
 * @param {Object} jsonObj - The updated timestamps JSON to save to file
-* @param {FinalizedOptions} optionsObj - Options
+* @param {import('./types').FinalizedOptions} optionsObj - Options
 */
 function updateTimestampsCacheFile(cacheFilePath, jsonObj, optionsObj) {
 	const {gitCommitHook} = optionsObj;
@@ -45,14 +43,14 @@ function updateTimestampsCacheFile(cacheFilePath, jsonObj, optionsObj) {
 /**
 * Get timestamps for a given file
 * @param {string} fullFilePath - The *full* file path to get stamps for
-* @param {StampCache} [cache] - Object with key/pair values corresponding to valid stamps
+* @param {import('./types').FinalizedOptions} optionsObj - Options
+* @param {import('./types').StampCache} [cache] - Object with key/pair values corresponding to valid stamps
 * @param {string} [cacheKey] - What is the stamp currently stored under for this file?
-* @param {FinalizedOptions} optionsObj - Options
-* @param {boolean} forceCreatedRefresh - If true, any existing created stamps in cache will be ignored, and re-calculated
-* @returns {Promise<StampObject>} - Timestamp object for file
+* @param {boolean} [forceCreatedRefresh] - If true, any existing created stamps in cache will be ignored, and re-calculated
+* @returns {Promise<import('./types').StampObject>} - Timestamp object for file
 */
 // eslint-disable-next-line max-params
-async function getTimestampsFromFile(fullFilePath, cache, cacheKey, optionsObj, forceCreatedRefresh) {
+async function getTimestampsFromFile(fullFilePath, optionsObj, cache, cacheKey, forceCreatedRefresh) {
 	const {gitCommitHook} = optionsObj;
 	const ignoreCreatedCache = typeof (forceCreatedRefresh) === 'boolean' ? forceCreatedRefresh : false;
 	const timestampsCache = typeof (cache) === 'object' ? cache : {};
@@ -65,7 +63,7 @@ async function getTimestampsFromFile(fullFilePath, cache, cacheKey, optionsObj, 
 	};
 	// Lookup values in cache
 	/**
-	* @type {StampObject}
+	* @type {import('./types').StampObject}
 	*/
 	let dateVals = timestampsCache[cacheKey];
 	dateVals = typeof (dateVals) === 'object' ? dateVals : {

--- a/src/stamp-handler.js
+++ b/src/stamp-handler.js
@@ -129,9 +129,7 @@ async function getTimestampsFromFilesBulk(filesToGet, optionsObj, cache, forceCr
 				dateVals = replaceZeros(dateVals, Math.floor((new Date()).getTime() / 1000));
 			} catch (error) {
 				/* istanbul ignore next */
-				console.log(`getting git dates failed for ${fullFilePath}`);
-				/* istanbul ignore next */
-				console.error(error);
+				console.log(`getting git dates failed for ${fullFilePath}`, error);
 			}
 
 			return {

--- a/src/tst-helpers.js
+++ b/src/tst-helpers.js
@@ -1,4 +1,3 @@
-// @ts-check
 const childProc = require('child_process');
 const path = require('path');
 const fse = require('fs-extra');
@@ -28,6 +27,10 @@ function wasLastCommitAutoAddCache(gitDir, cacheFileName) {
 }
 
 /* istanbul ignore next */
+/**
+ * Log something to the console and (if configured) log file
+ * @param {any} msg
+ */
 function iDebugLog(msg) {
 	console.log(msg);
 	if (typeof (msg) === 'object') {
@@ -70,7 +73,7 @@ function getTestFilePaths(dirPath) {
 /**
  * Build a local directory, filled with dummy files
  * @param {string} dirPath - Absolute path of where the directory should be created
- * @param {DirListing} dirListing - Listing of files to create, using absolute paths
+ * @param {import('./types').DirListing} dirListing - Listing of files to create, using absolute paths
  */
 function buildDir(dirPath, dirListing) {
 	/**
@@ -124,6 +127,10 @@ function buildTestDir(tempDirPath, gitInit, cacheFileName) {
 	};
 }
 
+/**
+ * Delete a temporary directory
+ * @param {string} tempDirPath
+ */
 async function removeTestDir(tempDirPath) {
 	// Just delete the top level dir
 	await fse.emptyDir(tempDirPath);
@@ -162,13 +169,13 @@ function touchFileSync(filePath, byAppending, OPT_useShell) {
 /**
  * Require that all input files have a corresponding stamp entry in results
  * @param {import('ava').ExecutionContext} testContext
- * @param {DirListing} files - Input file list
- * @param {StampCache} results - Output results from scraper
+ * @param {import('./types').DirListing} files - Input file list
+ * @param {import('./types').StampCache} results - Output results from scraper
  */
 function testForStampInResults(testContext, files, results) {
 	for (const key in files) {
 		if (typeof files[key] === 'object') {
-			/** @type {DirListing} */
+			/** @type {import('./types').DirListing} */
 			const dirListing = (files[key]);
 			testForStampInResults(testContext, dirListing, results);
 		} else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,5 @@ export interface FinalizedOptions {
 export interface DirListing {
 	[index: string]: string | DirListing;
 }
+
+export type UnpackedPromise<T> = T extends Promise<infer U> ? U : T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,17 @@
-type GitCommitHook = "pre" | "post" | "none";
+export type GitCommitHook = "pre" | "post" | "none";
 
-interface StampObject {
+export interface StampObject {
 	// the stamp of when the file was created
 	"created"?: number | boolean,
 	// the stamp of when the file was modified
 	"modified"?: number | boolean
 }
 
-interface StampCache {
+export interface StampCache {
 	[index:string]: StampObject
 }
-interface InputOptions {
+
+export interface InputOptions {
 	// Whether or not the timestamps should be saved to file
 	outputToFile?: boolean,
 	// the filename to save the timestamps to
@@ -26,14 +27,14 @@ interface InputOptions {
 	// Exception list of files that will override any blocks
 	allowFiles?: string[] | string,
 	// What triggered the execution
-	gitCommitHook?: GitCommitHook,
+	gitCommitHook?: string,
 	// Project root
 	projectRootPath?: string,
 	// Debug
 	debug?: boolean
 }
 
-interface FinalizedOptions {
+export interface FinalizedOptions {
 	outputToFile: boolean,
 	outputFileName?: string,
 	outputFileGitAdd?: boolean,
@@ -47,12 +48,6 @@ interface FinalizedOptions {
 	debug: boolean
 }
 
-interface DirListing {
+export interface DirListing {
 	[index: string]: string | DirListing;
-}
-
-declare namespace NodeJS {
-	interface Global {
-		calledViaCLI?: boolean;
-	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,10 @@
 		"outDir": "./dist",
 		"module": "commonjs",
 		"moduleResolution": "node",
-		"noImplicitAny": true
+		"noImplicitAny": true,
+		"esModuleInterop": true,
+		"target": "es2018",
+		"lib": ["es2018"]
 	},
 	"include": [
 		"*.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"declaration": true,
+		"emitDeclarationOnly": false,
+		"outDir": "./dist",
+		"module": "commonjs",
+		"moduleResolution": "node",
+		"noImplicitAny": true
+	},
+	"include": [
+		"*.d.ts",
+		"src/**/*"
+	]
+}

--- a/tst-helpers.js
+++ b/tst-helpers.js
@@ -80,10 +80,13 @@ async function makeTempDir() {
  * Build a local directory, filled with dummy files
  * @param {string} dirPath - Absolute path of where the directory should be created
  * @param {import('./src/types').DirListing} dirListing - Listing of files to create, using absolute paths
+ * @param {boolean} [empty] - Clear the directory out first, before building files
  */
-async function buildDir(dirPath, dirListing) {
+async function buildDir(dirPath, dirListing, empty = false) {
 	await fse.ensureDir(dirPath);
-	await fse.emptyDir(dirPath);
+	if (empty) {
+		await fse.emptyDir(dirPath);
+	}
 	/**
 	 * @param {string | import('./src/types').DirListing} pathOrObj
 	 * @returns {Promise<any>}
@@ -207,6 +210,15 @@ function testForStampInResults(testContext, files, results, skipFiles = []) {
 	}
 }
 
+/** @param {number} delayMs */
+const delay = (delayMs) => {
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			resolve();
+		}, delayMs);
+	});
+};
+
 module.exports = {
 	wasLastCommitAutoAddCache,
 	iDebugLog,
@@ -215,5 +227,6 @@ module.exports = {
 	getTestFilePaths,
 	buildDir,
 	testForStampInResults,
-	makeTempDir
+	makeTempDir,
+	delay
 };


### PR DESCRIPTION
This PR will merge some major improvements to this package, as well as fix some minor bugs.

Improvements:

 - Cleanup types, replace `@ts-check` with real TSC setup
 - Add exported types (generated from JSDoc)
 - Add performance test script
 - Improve performance (considerably, average ~2x)
 - Overhaul / major refactor of test setup
 - Some minor bug fixes / catching unusual input options