### PR TITLE
Transition Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,31 @@
+name: Node.js CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm install
+      - name: Run lint and tests
+        run: npm run test
+      - name: Collect / generate code coverage reporting
+        uses: ./node_modules/.bin/nyc report --reporter=text-lcov
+      - name: Upload code coverage reporting
+        uses: codecov/codecov-action@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -26,6 +26,10 @@ jobs:
           # cache: 'npm'
       - name: Install dependencies
         run: npm install
+      - name: Configure git for use with tests
+        run: |
+          git config --global user.name "GitHub Actions Tester"
+          git config --global user.email "noop@example.com"
       - name: Run lint and tests
         run: npm run test
       - name: Collect / generate code coverage reporting

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,6 +33,6 @@ jobs:
       - name: Run lint and tests
         run: npm run test
       - name: Collect / generate code coverage reporting
-        uses: ./node_modules/.bin/nyc report --reporter=text-lcov
+        run: npx --no-install nyc report --reporter=text-lcov
       - name: Upload code coverage reporting
         uses: codecov/codecov-action@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          # NOTE: This repo currently lacks a lockfile (e.g. `package-lock.json` file), which is why the below line is commented out
+          # this is for reasons roughly enumerated here - https://docs.joshuatz.com/cheatsheets/node-and-npm/npm-general/#including-the-lockfile
+          # If a lockfile is ever added, this should be uncommented to speed up setup
+          # cache: 'npm'
       - name: Install dependencies
         run: npm install
       - name: Run lint and tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - '14'
-  - '12'
-  - '10'
-after_script:
-  - './node_modules/.bin/nyc report --reporter=text-lcov > coverage.lcov && ./node_modules/.bin/codecov'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# git-date-extractor [![Build Status](https://travis-ci.org/joshuatz/git-date-extractor.svg?branch=main)](https://travis-ci.org/github/joshuatz/git-date-extractor) [![codecov](https://codecov.io/gh/joshuatz/git-date-extractor/badge.svg?branch=main)](https://codecov.io/gh/joshuatz/git-date-extractor?branch=main)  [![npm](https://img.shields.io/npm/v/git-date-extractor)](https://www.npmjs.com/package/git-date-extractor) [![demos](https://img.shields.io/badge/demos-github-informational)](https://github.com/joshuatz/git-date-extractor-demos)
+# git-date-extractor
+[![Build Status](https://github.com/joshuatz/git-date-extractor/actions/workflows/nodejs.yml/badge.svg)](https://github.com/joshuatz/git-date-extractor/tree/main/.github/workflows/nodejs.yml)
+[![codecov](https://codecov.io/gh/joshuatz/git-date-extractor/badge.svg?branch=main)](https://codecov.io/gh/joshuatz/git-date-extractor?branch=main)
+[![npm](https://img.shields.io/npm/v/git-date-extractor)](https://www.npmjs.com/package/git-date-extractor)
+[![demos](https://img.shields.io/badge/demos-github-informational)](https://github.com/joshuatz/git-date-extractor-demos)
 
 > Easily extract file dates based on git history, and optionally cache in a easy to parse JSON file.
 


### PR DESCRIPTION
Closes #15

The `travis-ci.org` version has been shut down for a while now; this PR finally transitions this repo over to using GitHub actions and drops all the Travis CI stuff.

Hopefully the `codecov` stuff will also transition smoothly (EDIT: Looks like it's working! 🎉 )